### PR TITLE
Add translation support to vue-form-builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,17 +14,17 @@
       }
     },
     "@babel/core": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.0.tgz",
-      "integrity": "sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
+      "integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.4.0",
-        "@babel/helpers": "^7.4.0",
-        "@babel/parser": "^7.4.0",
+        "@babel/helpers": "^7.4.3",
+        "@babel/parser": "^7.4.3",
         "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
         "@babel/types": "^7.4.0",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
@@ -105,9 +105,9 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.0.tgz",
-      "integrity": "sha512-2K8NohdOT7P6Vyp23QH4w2IleP8yG3UJsbRKwA4YP6H8fErcLkFuuEEqbF2/BYBKSNci/FWJiqm6R3VhM/QHgw==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.3.tgz",
+      "integrity": "sha512-UMl3TSpX11PuODYdWGrUeW6zFkdYhDn7wRLrOuNVM6f9L+S9CzmDXYyrp3MTHcwWjnzur1f/Op8A7iYZWya2Yg==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
@@ -187,9 +187,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz",
-      "integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.3.tgz",
+      "integrity": "sha512-H88T9IySZW25anu5uqyaC1DaQre7ofM+joZtAaO2F8NBdFfupH0SZ4gKjgSFVcvtx/aAirqA9L9Clio2heYbZA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -197,7 +197,7 @@
         "@babel/helper-split-export-declaration": "^7.0.0",
         "@babel/template": "^7.2.2",
         "@babel/types": "^7.2.2",
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -216,12 +216,12 @@
       "dev": true
     },
     "@babel/helper-regex": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
-      "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
+      "integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -281,13 +281,13 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.2.tgz",
-      "integrity": "sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.3.tgz",
+      "integrity": "sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
         "@babel/types": "^7.4.0"
       }
     },
@@ -334,9 +334,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
-      "integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+      "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -382,9 +382,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.0.tgz",
-      "integrity": "sha512-uTNi8pPYyUH2eWHyYWWSYJKwKg34hhgl4/dbejEjL+64OhbHjTX7wEVWMQl82tEmdDsGeu77+s8HHLS627h6OQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
+      "integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -515,9 +515,9 @@
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.0.tgz",
-      "integrity": "sha512-XGg1Mhbw4LDmrO9rSTNe+uI79tQPdGs0YASlxgweYRLZqo/EQktjaOV4tchL/UZbM0F+/94uOipmdNGoaGOEYg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
+      "integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
@@ -540,23 +540,23 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.0.tgz",
-      "integrity": "sha512-HySkoatyYTY3ZwLI8GGvkRWCFrjAGXUHur5sMecmCIdIharnlcWWivOqDJI76vvmVZfzwb6G08NREsrY96RhGQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
+      "integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz",
-      "integrity": "sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.3.tgz",
+      "integrity": "sha512-9Arc2I0AGynzXRR/oPdSALv3k0rM38IMFyto7kOCwb5F9sLUt2Ykdo3V9yUPR+Bgr4kb6bVEyLkPEiBhzcTeoA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-regex": "^7.4.3",
+        "regexpu-core": "^4.5.4"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
@@ -579,18 +579,18 @@
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.0.tgz",
-      "integrity": "sha512-vWdfCEYLlYSxbsKj5lGtzA49K3KANtb8qCPQ1em07txJzsBwY+cKJzBHizj5fl3CCx7vt+WPdgDLTHmydkbQSQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz",
+      "integrity": "sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz",
-      "integrity": "sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz",
+      "integrity": "sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
@@ -617,12 +617,12 @@
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.0.tgz",
-      "integrity": "sha512-iWKAooAkipG7g1IY0eah7SumzfnIT3WNhT4uYB2kIsvHnNSB6MDYVa5qyICSwaTBDBY2c4SnJ3JtEa6ltJd6Jw==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.3.tgz",
+      "integrity": "sha512-sMP4JqOTbMJMimqsSZwYWsMjppD+KRyDIUVW91pd7td0dZKAvPmhCaxhOzkzLParKwgQc7bdL9UNv+rpJB0HfA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-module-transforms": "^7.4.3",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-simple-access": "^7.1.0"
       }
@@ -676,9 +676,9 @@
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.0.tgz",
-      "integrity": "sha512-Xqv6d1X+doyiuCGDoVJFtlZx0onAX0tnc3dY8w71pv/O0dODAbusVv2Ale3cGOwfiyi895ivOBhYa9DhAM8dUA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz",
+      "integrity": "sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==",
       "dev": true,
       "requires": {
         "@babel/helper-call-delegate": "^7.4.0",
@@ -687,18 +687,18 @@
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.0.tgz",
-      "integrity": "sha512-SZ+CgL4F0wm4npojPU6swo/cK4FcbLgxLd4cWpHaNXY/NJ2dpahODCqBbAwb2rDmVszVb3SSjnk9/vik3AYdBw==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
+      "integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.13.4"
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.0.tgz",
-      "integrity": "sha512-1uv2h9wnRj98XX3g0l4q+O3jFM6HfayKup7aIu4pnnlzGz0H+cYckGBC74FZIWJXJSXAmeJ9Yu5Gg2RQpS4hWg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.3.tgz",
+      "integrity": "sha512-7Q61bU+uEI7bCUFReT1NKn7/X6sDQsZ7wL1sJ9IYMAO7cI+eg6x9re1cEw2fCRMbbTVyoeUKWSV1M6azEfKCfg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -755,14 +755,14 @@
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz",
-      "integrity": "sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz",
+      "integrity": "sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-regex": "^7.4.3",
+        "regexpu-core": "^4.5.4"
       }
     },
     "@babel/preset-env": {
@@ -817,18 +817,17 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
-      "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
-      "dev": true,
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+      "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.2.tgz",
-      "integrity": "sha512-y/Br/9uQnumcqcakkmobFqOTzYCWSS6Kuy1b2o7LTXR4lpeU0AhaOcPqIHW85LCxRWUDW5Vg0pU1KlE3YkORlg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.3.tgz",
+      "integrity": "sha512-anTLTF7IK8Hd5f73zpPzt875I27UaaTWARJlfMGgnmQhvEe1uNHQRKBUbXL0Gc0VEYiVzsHsTPso5XdK8NGvFg==",
       "dev": true,
       "requires": {
         "core-js": "^2.6.5",
@@ -847,16 +846,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
-      "integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+      "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.4.0",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.0",
-        "@babel/parser": "^7.4.0",
+        "@babel/parser": "^7.4.3",
         "@babel/types": "^7.4.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
@@ -924,9 +923,9 @@
       "dev": true
     },
     "@nuxt/opencollective": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.2.1.tgz",
-      "integrity": "sha512-NP2VSUKRFGutbhWeKgIU0MnY4fmpH8UWxxwTJNPurCQ5BeWhOxp+Gp5ltO39P/Et/J2GYGb3+ALNqZJ+5cGBBw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.2.2.tgz",
+      "integrity": "sha512-ie50SpS47L+0gLsW4yP23zI/PtjsDRglyozX2G09jeiUazC1AJlGPZo0JUs9iuCDUoIgsDEf66y7/bSfig0BpA==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
@@ -962,6 +961,21 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        }
+      }
+    },
+    "@panter/vue-i18next": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@panter/vue-i18next/-/vue-i18next-0.15.0.tgz",
+      "integrity": "sha512-Np9/N2lgprP12adE+ZiNtq2zV1mjGN3+LKLI18UpL/dwKeHBIiikbYs+MT7L95XhPGCKJZpOI9pw6/lpakgZaQ==",
+      "requires": {
+        "deepmerge": "^2.0.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+          "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
         }
       }
     },
@@ -1064,9 +1078,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.12.0.tgz",
-      "integrity": "sha512-Lg00egj78gM+4aE0Erw05cuDbvX9sLJbaaPwwRtdCdAMnIudqrQZ0oZX98Ek0yiSK/A2nubHgJfvII/rTT2Dwg=="
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
+      "integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng=="
     },
     "@types/q": {
       "version": "1.5.2",
@@ -1146,9 +1160,9 @@
       }
     },
     "@vue/babel-preset-app": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-3.5.3.tgz",
-      "integrity": "sha512-PcREZtY5JOEct5IsDdLJ+RLoTmpNETdljGukw8lhvuUmaqDiLpzMfTnxQ4FJHS9A+SNs6W+OaWj+NyN7nTlf2Q==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-3.5.5.tgz",
+      "integrity": "sha512-kK2DkQ+uGOjDnVjgn8A3Rczic55rI42nMESmwWfrfjssPeFQLGqiJixk9eQccHNBjyHcl3D+UOWx+EHQbpPByg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -1212,9 +1226,9 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+          "integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg==",
           "dev": true
         }
       }
@@ -1231,9 +1245,9 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+          "integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg==",
           "dev": true
         }
       }
@@ -1245,13 +1259,13 @@
       "dev": true
     },
     "@vue/cli-plugin-babel": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-babel/-/cli-plugin-babel-3.5.3.tgz",
-      "integrity": "sha512-N0EJV+AdY5QnpGXECbv3kEpBjcKZSKy7bRkOOxpvIVHOtNYMdp0TXI5ibfuCAs53CAufcuJwm1CqeQA8uELv1w==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-babel/-/cli-plugin-babel-3.5.5.tgz",
+      "integrity": "sha512-ew+EWL2ur234wqQfI1AvWcghjWQ2PlSVpUAfnDlejplDzXSHz7455IIwN7Auhs7siEbls3EVd/bl/ieKGjwY5g==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.0.0",
-        "@vue/babel-preset-app": "^3.5.3",
+        "@vue/babel-preset-app": "^3.5.5",
         "@vue/cli-shared-utils": "^3.5.1",
         "babel-loader": "^8.0.5",
         "webpack": ">=4 < 4.29"
@@ -2898,14 +2912,14 @@
       }
     },
     "browserslist": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.2.tgz",
-      "integrity": "sha512-zmJVLiKLrzko0iszd/V4SsjTaomFeoVzQGYYOYgRgsbh7WNh95RgDB0CmBdFWYs/3MyFSt69NypjL/h3iaddKQ==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.3.tgz",
+      "integrity": "sha512-Tx/Jtrmh6vFg24AelzLwCaCq1IUJiMDM1x/LPzqbmbktF8Zo7F9ONUpOWsFK6TtdON95mSMaQUWqi0ilc8xM6g==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000951",
-        "electron-to-chromium": "^1.3.116",
-        "node-releases": "^1.1.11"
+        "caniuse-lite": "^1.0.30000955",
+        "electron-to-chromium": "^1.3.122",
+        "node-releases": "^1.1.12"
       }
     },
     "bser": {
@@ -3577,9 +3591,9 @@
       "dev": true
     },
     "consola": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.5.7.tgz",
-      "integrity": "sha512-KZteEB71fuSoSDgJoYEo/dIvwofWMU/bI/n+wusLYHPp+c7KcxBGZ0P8CzTCko2Jp0xsrbLjmLuUo4jyIWa6vQ==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.5.8.tgz",
+      "integrity": "sha512-fYv1M0rNJw4h0CZUx8PX02Px7xQhA+vNHpV8DBCGMoozp2Io/vrSXhhEothaRnSt7VMR0rj2pt9KKLXa5amrCw==",
       "dev": true
     },
     "console-browserify": {
@@ -4748,9 +4762,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.120",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.120.tgz",
-      "integrity": "sha512-p1pgKOSSgcROCRiZoJ5H5wFmhqdA0L3yLL9mlfcmdA4V60IDCrsvhNqN8rLPe9e3B772Gm02kBkL1GM/g2lENg==",
+      "version": "1.3.122",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.122.tgz",
+      "integrity": "sha512-3RKoIyCN4DhP2dsmleuFvpJAIDOseWH88wFYBzb22CSwoFDSWRc4UAMfrtc9h8nBdJjTNIN3rogChgOy6eFInw==",
       "dev": true
     },
     "elliptic": {
@@ -5845,24 +5859,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5872,12 +5890,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -5886,34 +5906,40 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5922,25 +5948,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5949,13 +5979,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5971,7 +6003,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5985,13 +6018,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6000,7 +6035,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6009,7 +6045,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6019,18 +6056,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -6038,13 +6078,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -6052,12 +6094,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -6066,7 +6110,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6075,7 +6120,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -6083,13 +6129,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+          "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6100,7 +6148,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
+          "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6118,7 +6167,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6128,13 +6178,15 @@
         },
         "npm-bundled": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
+          "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.2.0.tgz",
+          "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6144,7 +6196,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6156,18 +6209,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -6175,19 +6231,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6197,19 +6256,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6221,7 +6283,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -6229,7 +6292,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6244,7 +6308,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6253,42 +6318,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -6298,7 +6370,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6307,7 +6380,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -6315,13 +6389,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6336,13 +6412,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6351,12 +6429,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         }
       }
@@ -6524,14 +6604,14 @@
       "dev": true
     },
     "globby": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-9.1.0.tgz",
-      "integrity": "sha512-VtYjhHr7ncls724Of5W6Kaahz0ag7dB4G62/2HsN+xEKG6SrPzM1AJMerGxQTwJGnN9reeyxdvXbuZYpfssCvg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+      "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
       "dev": true,
       "requires": {
         "@types/glob": "^7.1.1",
         "array-union": "^1.0.2",
-        "dir-glob": "^2.2.1",
+        "dir-glob": "^2.2.2",
         "fast-glob": "^2.2.6",
         "glob": "^7.1.3",
         "ignore": "^4.0.3",
@@ -6928,9 +7008,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -7002,6 +7082,14 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "i18next": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-15.0.8.tgz",
+      "integrity": "sha512-ayzNwJ9NHtqEeAG0nQ6yKFbIpZULpDeesjVnfWQaPwbH7Anee8QwRAYPNWHtFCmDZV9FZaKiEbfo1scH8+KSDg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -10741,9 +10829,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.12.tgz",
-      "integrity": "sha512-Y+AQ1xdjcgaEzpL65PBEF3fnl1FNKnDh9Zm+AUQLIlyyqtSc4u93jyMN4zrjMzdwKQ10RTr3tgY1x7qpsfF/xg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.13.tgz",
+      "integrity": "sha512-fKZGviSXR6YvVPyc011NHuJDSD8gFQvLPmc2d2V3BS4gr52ycyQ1Xzs7a8B+Ax3Ni/W+5h1h4SqmzeoA8WZRmA==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -10853,91 +10941,10 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwsapi": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.2.tgz",
-      "integrity": "sha512-TQOQNxqEdxVjwgwNZyvKDF0vALmzQKZJEZwE3fZWDb7Ns5Hw6l9PxJTGKOHZGsmf7R6grsOe8lWxI43Clz79zg==",
-      "dev": true,
-      "requires": {
-        "jsdom": "^14.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
-          "dev": true
-        },
-        "jsdom": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-14.0.0.tgz",
-          "integrity": "sha512-/VkyPmdtbwqpJSkwDx3YyJ3U1oawYNB/h5z8vTUZGAzjtu2OHTeFRfnJqyMHsJ5Cyes23trOmvUpM1GfHH1leA==",
-          "dev": true,
-          "requires": {
-            "abab": "^2.0.0",
-            "acorn": "^6.0.4",
-            "acorn-globals": "^4.3.0",
-            "array-equal": "^1.0.0",
-            "cssom": "^0.3.4",
-            "cssstyle": "^1.1.1",
-            "data-urls": "^1.1.0",
-            "domexception": "^1.0.1",
-            "escodegen": "^1.11.0",
-            "html-encoding-sniffer": "^1.0.2",
-            "nwsapi": "^2.0.9",
-            "parse5": "5.1.0",
-            "pn": "^1.1.0",
-            "request": "^2.88.0",
-            "request-promise-native": "^1.0.5",
-            "saxes": "^3.1.5",
-            "symbol-tree": "^3.2.2",
-            "tough-cookie": "^2.5.0",
-            "w3c-hr-time": "^1.0.1",
-            "w3c-xmlserializer": "^1.0.1",
-            "webidl-conversions": "^4.0.2",
-            "whatwg-encoding": "^1.0.5",
-            "whatwg-mimetype": "^2.3.0",
-            "whatwg-url": "^7.0.0",
-            "ws": "^6.1.2",
-            "xml-name-validator": "^3.0.0"
-          }
-        },
-        "parse5": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-          "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
-          "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "dev": true,
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
-          }
-        },
-        "whatwg-url": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
-          "dev": true,
-          "requires": {
-            "lodash.sortby": "^4.7.0",
-            "tr46": "^1.0.1",
-            "webidl-conversions": "^4.0.2"
-          }
-        },
-        "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
-        }
-      }
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.3.tgz",
+      "integrity": "sha512-RowAaJGEgYXEZfQ7tvvdtAQUKPyTR6T6wNu0fwlNsGQYr/h3yQc6oI8WnVZh3Y/Sylwc+dtAlvPqfFZjhTyk3A==",
+      "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -11157,9 +11164,9 @@
       }
     },
     "ora": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-3.2.0.tgz",
-      "integrity": "sha512-XHMZA5WieCbtg+tu0uPF8CjvwQdNzKCX6BVh3N6GFsEXH40mTk5dsw/ya1lBTUGJslcEFJFQ8cBhOgkkZXQtMA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-3.3.1.tgz",
+      "integrity": "sha512-k80K0Q6hYokgaJoFePrxJfQJeZKZ38GVEI/BLNxAJXtQZGcMc5jLIAO9ttoI8A52wvfHmdySy8F52gz/sfFFFA==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -11301,9 +11308,9 @@
       "dev": true
     },
     "p-try": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-      "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
     "pako": {
@@ -12634,8 +12641,7 @@
     "regenerator-runtime": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-      "dev": true
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
     "regenerator-transform": {
       "version": "0.13.4",
@@ -13061,15 +13067,6 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
-    },
-    "saxes": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.9.tgz",
-      "integrity": "sha512-FZeKhJglhJHk7eWG5YM0z46VHmI3KJpMBAQm3xa9meDvd+wevB5GuBB0wc0exPInZiBBHqi00DbS8AcvCGCFMw==",
-      "dev": true,
-      "requires": {
-        "xmlchars": "^1.3.1"
-      }
     },
     "schema-utils": {
       "version": "0.4.7",
@@ -13639,9 +13636,9 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -14570,9 +14567,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.2.tgz",
-      "integrity": "sha512-imog1WIsi9Yb56yRt5TfYVxGmnWs3WSGU73ieSOlMVFwhJCA9W8fqFFMMj4kgDqiS/80LGdsYnWL7O9UcjEBlg==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.3.tgz",
+      "integrity": "sha512-rIQPT2UMDnk4jRX+w4WO84/pebU2jiLsjgIyrCktYgSvx28enOE3iYQMr+BD1rHiitWnDmpu0cY/LfIEpKcjcw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -15040,9 +15037,9 @@
       }
     },
     "vue-json-pretty": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/vue-json-pretty/-/vue-json-pretty-1.4.1.tgz",
-      "integrity": "sha512-EYLyhTb21unHr91U2W9Bo4EWA2TA67uVmRx024f8UBZVOqCkddSV4IBALzy24h+yo+XzQg6yTYWe+rbcxqXokQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vue-json-pretty/-/vue-json-pretty-1.6.0.tgz",
+      "integrity": "sha512-yLQ2Kuk4S+fPxVncww9kPO72pTiGrZfgyi1P+Vhmy1kR7J1CwzYli8uyhgdTMPaz0h2zqiDF0VGtzX+FTrwbig==",
       "dev": true
     },
     "vue-loader": {
@@ -15134,17 +15131,6 @@
       "dev": true,
       "requires": {
         "browser-process-hrtime": "^0.1.2"
-      }
-    },
-    "w3c-xmlserializer": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
-      "integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
-      "dev": true,
-      "requires": {
-        "domexception": "^1.0.1",
-        "webidl-conversions": "^4.0.2",
-        "xml-name-validator": "^3.0.0"
       }
     },
     "walker": {
@@ -15453,9 +15439,9 @@
           }
         },
         "mem": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-          "integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
           "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
@@ -15464,9 +15450,9 @@
           }
         },
         "mimic-fn": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-          "integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "ms": {
@@ -15732,12 +15718,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
-      "dev": true
-    },
-    "xmlchars": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-1.3.1.tgz",
-      "integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw==",
       "dev": true
     },
     "xregexp": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
   ],
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.6.1",
+    "@panter/vue-i18next": "^0.15.0",
     "@processmaker/vue-form-elements": "^0.7.0",
     "css-tree": "^1.0.0-alpha.29",
     "expr-eval": "^1.2.2",
+    "i18next": "^15.0.8",
     "monaco-editor-webpack-plugin": "^1.7.0",
     "mustache": "^3.0.1",
     "node-sass": "^4.9.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,16 +3,16 @@
         <nav class="navbar  navbar-expand-lg  navbar navbar-dark bg-dark">
             <ul class="navbar-nav mr-auto">
                 <li class="nav-item active">
-                    <a class="nav-link" @click="mode = 'editor'" href="#">Editor</a>
+                    <a class="nav-link" @click="mode = 'editor'" href="#">{{$t('Editor')}}</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" @click="mode = 'preview'" href="#">Preview</a>
+                    <a class="nav-link" @click="mode = 'preview'" href="#">{{$t('Preview')}}</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" @click="openComputedProperties" href="#">Computed Properties</a>
+                    <a class="nav-link" @click="openComputedProperties" href="#">{{$t('Computed Properties')}}</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" @click="openCustomCSS" href="#">Custom CSS</a>
+                    <a class="nav-link" @click="openCustomCSS" href="#">{{$t('Custom CSS')}}</a>
                 </li>
             </ul>
         </nav>
@@ -24,13 +24,13 @@
 
             <div id="data-input" class="w-25 border overflow-auto">
                 <div class="card-header">
-                    Data Input
+                    {{$t('Data Input')}}
                 </div>
                 <div class="card-body mb-5">
                     <div class="alert"
                          :class="{'alert-success': previewInputValid, 'alert-danger': !previewInputValid}">
-                        <span v-if="previewInputValid">Valid JSON Data Object</span>
-                        <span v-else>Invalid JSON Data Object</span>
+                        <span v-if="previewInputValid">{{$t('Valid JSON Data Object')}}</span>
+                        <span v-else>{{$t('Invalid JSON Data Object')}}</span>
                     </div>
                     <form-text-area rows="18" v-model="previewInput"></form-text-area>
                 </div>
@@ -54,7 +54,7 @@
 
             <div id="data-preview" class="w-25 border overflow-auto mb-5">
                 <div class="card-header">
-                    Data Preview
+                    {{$t('Data Preview')}}
                 </div>
                 <vue-json-pretty :data="previewData" class="card-body"></vue-json-pretty>
             </div>

--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -5,7 +5,7 @@
     id="computed-properties"
     centered
     hide-footer
-    title="Computed Properties"
+    :title="$t('Computed Properties')"
     @hidden="displayTableList"
   >
     <b-alert
@@ -13,31 +13,38 @@
       dismissible
       :show="showDismissibleAlert"
       @dismissed="showDismissibleAlert=false"
-    >{{ message }}</b-alert>
+    >{{ $t(message) }}</b-alert>
     <template v-if="displayList">
       <b-row class="float-right">
         <div class="m-2">
           <b-btn size="sm" variant="primary" @click.stop="displayFormProperty">
-            <i class="fas fa-plus"></i> Add Property
+            <i class="fas fa-plus"></i> {{ $t('Add Property') }}
           </b-btn>
         </div>
       </b-row>
 
       <b-table :items="current" :fields="fields" responsive striped bordered small hover fixed>
+      <template slot="HEAD_property" slot-scope="data">
+      {{ $t(data.label) }}
+      </template>
+      <template slot="HEAD_actions" slot-scope="data">
+      {{ $t(data.label) }}
+      </template>
+
         <template slot="actions" slot-scope="row">
           <!-- we use @click.stop here to prevent emitting of a 'row-clicked' event  -->
           <a
             variant="action"
             @click.stop="row.toggleDetails"
             class="btn btn-lg p-0 mr-2 border-0 bg-transparent"
-            title="Details"
+            :title="$t('Details')"
           >
             <i class="fa fa-list-alt fa-1x"></i>
           </a>
           <a
             size="lg"
             variant="action"
-            title="edit"
+            :title="$t('edit')"
             class="btn btn-lg p-0 mr-2 border-0 bg-transparent"
             @click.stop="editProperty(row.item)"
           >
@@ -46,7 +53,7 @@
           <a
             size="lg"
             variant="action"
-            title="Delete"
+            :title="$t('Delete')"
             class="btn btn-lg p-0 mr-2 border-0 bg-transparent"
             @click.stop="deleteProperty(row.item)"
           >
@@ -57,17 +64,17 @@
           <b-card>
             <b-row class="mb-1">
               <b-col sm="3" class="text-sm-right">
-                <b>Field:</b>
+                <b>{{$t('Field:')}}</b>
               </b-col>
-              <b-col>{{ row.item.property }}</b-col>
+              <b-col>{{ $t(row.item.property) }}</b-col>
             </b-row>
             <b-row class="mb-1">
               <b-col sm="3" class="text-sm-right">
-                <b>Formula:</b>
+                <b>{{$t('Formula:')}}</b>
               </b-col>
-              <b-col>{{ row.item.formula }}</b-col>
+              <b-col>{{ $t(row.item.formula) }}</b-col>
             </b-row>
-            <b-button class="float-right" size="sm" @click="row.toggleDetails">Hide Details</b-button>
+            <b-button class="float-right" size="sm" @click="row.toggleDetails">{{$t('Hide Details')}}</b-button>
           </b-card>
         </template>
       </b-table>
@@ -76,18 +83,18 @@
     <template v-else>
       <form-input
         v-model="add.property"
-        label="Property Name"
+        :label="$t('Property Name')"
         name="property name"
         validation="required"
       ></form-input>
       <form-text-area
         v-model="add.name"
-        label="Description"
+        :label="$t('Description')"
         name="property description"
         validation="required"
       ></form-text-area>
       <div class="form-group" style='position: relative;'>
-        <label>Formula</label>
+        <label>{{$t('Formula')}}</label>
         <div class="float-right">
           <a class='btn btn-sm' :class="expressionTypeClass" @click="switchExpressionType">
             <i class="fas fa-square-root-alt"></i>
@@ -100,14 +107,14 @@
         <div v-show="isJS" class="editor-border" :class="{'is-invalid':!add.formula}"></div>
         <monaco-editor v-show="isJS" :options="monacoOptions" :minimap="{enabled:false}" class="editor" v-model="add.formula" language="javascript">
         </monaco-editor>
-        <div v-if="!add.formula" class="invalid-feedback"><div>The property formula field is required.</div></div>
+        <div v-if="!add.formula" class="invalid-feedback"><div>{{$t('The property formula field is required.')}}</div></div>
       </div>
       <button
         class="btn btn-secondary float-right ml-2"
         @click="validateData"
         :disabled="disabled"
       >Save Property</button>
-      <button class="btn btn-outline-secondary float-right" @click="displayTableList">Cancel</button>
+      <button class="btn btn-outline-secondary float-right" @click="displayTableList">{{$t('Cancel')}}</button>
     </template>
   </b-modal>
 </template>

--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -113,7 +113,7 @@
         class="btn btn-secondary float-right ml-2"
         @click="validateData"
         :disabled="disabled"
-      >Save Property</button>
+      >{{$t('Save Property')}}</button>
       <button class="btn btn-outline-secondary float-right" @click="displayTableList">{{$t('Cancel')}}</button>
     </template>
   </b-modal>

--- a/src/components/custom-css.vue
+++ b/src/components/custom-css.vue
@@ -4,14 +4,14 @@
     size="lg"
     id="custom-css"
     centered
-    title="Custom CSS"
+    :title="$t('Custom CSS')"
     @ok="save"
     @cancel="close"
     @hide="hide"
     cancel-variant="btn btn-outline-secondary"
     ok-variant="btn btn-secondary ml-2"
   >
-    <p>You can set CSS Selector names in the inspector. Use them here with [selector='my-selector']</p>
+    <p>{{$t("You can set CSS Selector names in the inspector. Use them here with [selector='my-selector']")}}</p>
     <div class="editor">
       <monaco-editor :options="monacoOptions" class="monaco" v-model="innerValue"/>
     </div>
@@ -19,8 +19,8 @@
     <b-alert :show="cssErrors != ''" variant="danger">
       <pre>{{ cssErrors }}</pre>
     </b-alert>
-
-    <div slot="modal-ok">Save</div>
+    <div slot="modal-cancel">{{$t('Cancel')}}</div>
+    <div slot="modal-ok">{{$t('Save')}}</div>
   </b-modal>
 </template>
 

--- a/src/components/inspector/color-select.vue
+++ b/src/components/inspector/color-select.vue
@@ -12,7 +12,7 @@
          <i class="fas fa-square" :class="'text-' + option.value"></i>
       </a>
     </div>
-    <small class="form-text text-muted">{{helper}}</small>
+    <small class="form-text text-muted">{{$t(helper)}}</small>
   </div>
 </template>
 

--- a/src/components/inspector/color-select.vue
+++ b/src/components/inspector/color-select.vue
@@ -9,7 +9,7 @@
          class="btn btn-sm"
          :class="{'btn-outline-light': option.value!==value  , 'btn-outline-secondary': option.value===value}"
          @click="selectColor(option.value)">
-         <i class="fas fa-square" :class="'text-' + option.content"></i>
+         <i class="fas fa-square" :class="'text-' + option.value"></i>
       </a>
     </div>
     <small class="form-text text-muted">{{helper}}</small>

--- a/src/components/inspector/container-columns.vue
+++ b/src/components/inspector/container-columns.vue
@@ -4,7 +4,7 @@
         <h3>{{label}}</h3>
         <form-checkbox name="type"
                        toggle="true"
-                       label="Show in Json Format "
+                       :label="$t('Show in Json Format')"
                        v-model="displayList"
                        helper="">
         </form-checkbox>
@@ -21,16 +21,16 @@
                             helper="It must be a correct json format."
                             v-model="dataJson">
             </form-text-area>
-            <b-btn @click="saveDataJson" :disabled="!isValidJson">Save</b-btn>
+            <b-btn @click="saveDataJson" :disabled="!isValidJson">{{ $t('Save') }}</b-btn>
         </template>
 
         <template v-else>
             <table class="table table-sm">
                 <thead class="thead-dark">
                 <tr>
-                    <th>Column</th>
-                    <th>Colspan</th>
-                    <th>Remove</th>
+                    <th>{{ $t('Column') }}</th>
+                    <th>{{ $t('Colspan') }}</th>
+                    <th>{{ $t('Remove') }}</th>
                 </tr>
                 </thead>
                 <draggable
@@ -50,12 +50,12 @@
                     </tr>
                 </draggable>
             </table>
-            <b-btn v-b-modal.addOptionModal>Add Column</b-btn>
+            <b-btn v-b-modal.addOptionModal>{{ $t('Add Column') }}</b-btn>
             <small v-if="helper" class="form-text text-muted">{{helper}}</small>
 
-            <b-modal @cancel="resetAdd" @ok="addNewOption" id="addOptionModal" title="Add New Column">
+            <b-modal @cancel="resetAdd" @ok="addNewOption" id="addOptionModal" :title="$t('Add New Column')">
                 <form-input
-                        label="Column Width"
+                        :label="$t('Column Width')"
                         v-model="addContent"
                         validate="required|numeric|between:1,12"
                         :error="this.addError"
@@ -140,13 +140,13 @@
         let newOptions = JSON.parse(JSON.stringify(this.options));
 
         if (isNaN(this.addContent)) {
-          this.addError = "This value must be numeric";
+          this.addError = $t("This value must be numeric");
           event.preventDefault();
           return;
         }
 
         if (!(0 < this.addContent && this.addContent < 13)) {
-          this.addError = "This value must be between 1-12";
+          this.addError = $t("This value must be between 1-12");
           event.preventDefault();
           return;
         }
@@ -159,7 +159,7 @@
         });
 
         if (sum + Number(this.addContent) > 12) {
-          this.addError = "The total size of the columns exceeds 12.";
+          this.addError = $t("The total size of the columns exceeds 12");
           event.preventDefault();
           return;
         }

--- a/src/components/inspector/container-columns.vue
+++ b/src/components/inspector/container-columns.vue
@@ -51,7 +51,7 @@
                 </draggable>
             </table>
             <b-btn v-b-modal.addOptionModal>{{ $t('Add Column') }}</b-btn>
-            <small v-if="helper" class="form-text text-muted">{{helper}}</small>
+            <small v-if="helper" class="form-text text-muted">{{$t(helper)}}</small>
 
             <b-modal @cancel="resetAdd" @ok="addNewOption" id="addOptionModal" :title="$t('Add New Column')">
                 <form-input

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -4,7 +4,7 @@
         <h3>{{label}}</h3>
         <form-checkbox name="type"
                        toggle="true"
-                       label="Show in Json Format "
+                       :label="$t('Show in Json Format')"
                        v-model="displayList"
                        helper="">
         </form-checkbox>
@@ -12,25 +12,25 @@
         <template v-if="displayList">
             <div class="alert"
                  :class="{'alert-success': isValidJson, 'alert-danger': !isValidJson}">
-                <span v-if="isValidJson">Valid JSON Data Object</span>
-                <span v-else>Invalid JSON Data Object</span>
+                <span v-if="isValidJson">{{ $t('Valid JSON Data Object') }}</span>
+                <span v-else>{{ $t('Invalid JSON Data Object') }}</span>
             </div>
             <form-text-area name="dataJson"
                             label="Json Options"
                             rows="8"
-                            helper="It must be a correct json format."
+                            :helper="$t('It must be a correct json format')"
                             v-model="dataJson">
             </form-text-area>
-            <b-btn @click="saveDataJson" :disabled="!isValidJson">Save</b-btn>
+            <b-btn @click="saveDataJson" :disabled="!isValidJson">{{ $t('Save') }}</b-btn>
         </template>
 
         <template v-else>
             <table class="table table-sm">
                 <thead class="thead-dark">
                 <tr>
-                    <th>Value</th>
-                    <th>Content</th>
-                    <th>Actions</th>
+                    <th>{{ $t('Value') }}</th>
+                    <th>{{ $t('Content') }}</th>
+                    <th>{{ $t('Actions') }}</th>
                 </tr>
                 </thead>
                 <draggable @update="updateSort"
@@ -48,11 +48,11 @@
                     </tr>
                 </draggable>
             </table>
-            <b-btn v-b-modal.addOptionModal>Add Option</b-btn>
+            <b-btn v-b-modal.addOptionModal>{{ $t('Add Option') }}</b-btn>
 
-            <b-modal centered @cancel="resetAdd" @ok="addNewOption" id="addOptionModal" title="Add New Option">
-                <form-input label="Field Name" v-model="addValue" :error="this.addError"></form-input>
-                <form-input label="Field Label" v-model="addContent"></form-input>
+            <b-modal centered @cancel="resetAdd" @ok="addNewOption" id="addOptionModal" :title="$t('Add New Option')">
+                <form-input :label="$t('Field Name')" v-model="addValue" :error="this.addError"></form-input>
+                <form-input :label="$t('Field Label')" v-model="addContent"></form-input>
             </b-modal>
         </template>
 
@@ -130,7 +130,7 @@
         for (var existingOption of newOptions) {
           if (existingOption.value === this.addValue) {
             // Found, let's return cancel?
-            this.addError = "This value already exists in the list of options";
+            this.addError = this.$t("This value already exists in the list of options");
             event.preventDefault();
             return;
           }

--- a/src/components/renderer/form-button.vue
+++ b/src/components/renderer/form-button.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="form-group">
-        <button @click="click" :class="classList" :name="name" v-model="fieldValue">dddddd {{ $t(label) }}</button>
+        <button @click="click" :class="classList" :name="name" v-model="fieldValue">{{ $t(label) }}</button>
     </div>
 </template>
 

--- a/src/components/renderer/form-button.vue
+++ b/src/components/renderer/form-button.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="form-group">
-        <button @click="click" :class="classList" :name="name" v-model="fieldValue">{{ $t(label) }}</button>
+        <button @click="click" :class="classList" :name="name" v-model="fieldValue">{{ label }}</button>
     </div>
 </template>
 

--- a/src/components/renderer/form-button.vue
+++ b/src/components/renderer/form-button.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="form-group">
-        <button @click="click" :class="classList" :name="name" v-model="fieldValue">{{label}}</button>
+        <button @click="click" :class="classList" :name="name" v-model="fieldValue">dddddd {{ $t(label) }}</button>
     </div>
 </template>
 

--- a/src/components/renderer/form-record-list-static.vue
+++ b/src/components/renderer/form-record-list-static.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="record-list">
-        <h4>{{label}}</h4>
+        <h4>{{ $t(label) }}</h4>
         <table>
             <thead>
                 <tr>

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -6,12 +6,12 @@
             </div>
             <div class="col text-right">
                 <button class="btn btn-primary" v-if="editable && !selfReferenced" @click="showAddForm">
-                    Add Record
+                    {{ $t('Add Record') }}
                 </button>
             </div>
         </div>
         <div class="alert alert-danger" v-if="!value">
-            There is no records in this list or the data is invalid.
+            {{ $t('There is no records in this list or the data is invalid.') }}
         </div>
         <template v-else>
             <vuetable :per-page="perPage" ref="vuetable" :data-manager="dataManager" :fields="tableFields"
@@ -22,7 +22,7 @@
                         <div class="btn-group" role="group" aria-label="Actions">
                             <button @click="showEditForm(props.rowIndex)" class="btn btn-primary">Edit</button>
                             <button @click="showDeleteConfirmation(props.rowIndex)" class="btn btn-primary">
-                                Delete
+                                {{ $t('Delete') }}
                             </button>
                         </div>
                     </div>
@@ -35,7 +35,7 @@
                  size="lg"
                  v-if="editable && !selfReferenced"
                  ref="addModal"
-                 title="Add Record">
+                 :title="$t('Add Record')">
             <vue-form-renderer :page="form"
                                ref="addRenderer"
                                v-model="addItem"
@@ -46,7 +46,7 @@
                  size="lg"
                  v-if="editable && !selfReferenced"
                  ref="editModal"
-                 title="Edit Record">
+                 :title="$t('Edit Record')">
             <vue-form-renderer :page="form"
                                ref="editRenderer"
                                v-model="editItem"
@@ -57,19 +57,19 @@
                  size="lg"
                  v-if="editable && !selfReferenced"
                  ref="deleteModal"
-                 title="Delete Record">
-            <p>Are you sure you want to remove this record?</p>
+                 :title="$t('Delete Record')">
+            <p>{{ $t('Are you sure you want to remove this record?') }}</p>
         </b-modal>
         <b-modal @ok="hideInformation"
                  size="sm"
                  v-if="editable && !selfReferenced"
                  ref="infoModal"
-                 title="Information form"
+                 :title="$t('Information form')"
                  ok-only>
-            <p>The form to be displayed is not assigned..</p>
+            <p>{{$t('The form to be displayed is not assigned..')}}</p>
         </b-modal>
         <div v-if="editable && selfReferenced" class="alert alert-danger">
-            The Record List control is not allowed to reference other controls on its own page to add or edit records. Specify a secondary page with controls to enter records.
+            {{$t('The Record List control is not allowed to reference other controls on its own page to add or edit records. Specify a secondary page with controls to enter records.')}}
         </div>
     </div>
 </template>

--- a/src/components/renderer/form-text.vue
+++ b/src/components/renderer/form-text.vue
@@ -32,7 +32,7 @@ export default {
       try {
         return Mustache.render(this.label, this.validationData);
       } catch (e) {
-        return this.label;
+        return this.$t(this.label);
       }
     }
   }

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -270,6 +270,17 @@
       },
       currentPage() {
         this.inspection = {};
+      },
+      inspection(e) {
+        for (var i in e.inspector) {
+          e.inspector[i].config.label = this.$t(e.inspector[i].config.label)
+          e.inspector[i].config.helper = this.$t(e.inspector[i].config.helper)
+          if (e.inspector[i].config.options) {
+            for (var io in e.inspector[i].config.options) {
+              e.inspector[i].config.options[io].content = this.$t(e.inspector[i].config.options[io].content)
+            }
+          }
+        }
       }
     },
     methods: {

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -3,7 +3,7 @@
         <div class="d-flex h-100 mb-5">
 
             <div class="w-25 border overflow-auto">
-                <div class="card-header">Controls</div>
+                <div class="card-header">{{$t('Controls')}}</div>
                 <div class="card-body d-flex flex-wrap mb-5">
                     <draggable id="controls"
                                v-model="controls"
@@ -16,7 +16,7 @@
                                 <img v-if="element['editor-icon']" :src="element['editor-icon']">
                                 <i v-if="element['fa-icon']" :class="element['fa-icon']"></i>
                             </div>
-                            <div class="font-weight-normal text-capitalize">{{element.label}}</div>
+                            <div class="font-weight-normal text-capitalize">{{$t(element.label)}}</div>
                         </div>
                     </draggable>
                 </div>
@@ -36,7 +36,7 @@
                             {{data.name}}
                             <button class="btn btn-sm btn-primary mr-1"
                                     @click="openEditPageModal(page)">
-                                Edit
+                                {{$t('Edit')}}
                             </button>
                             <button class="btn btn-sm btn-danger mr-1"
                                     @click="confirmDelete(page)"
@@ -46,7 +46,7 @@
                     </li>
                     <li slot="footer" class="nav-item">
                         <a class="nav-link" href="#">
-                            <b-btn variant="success" size="sm" v-b-modal.addPageModal>+ Add Page</b-btn>
+                            <b-btn variant="success" size="sm" v-b-modal.addPageModal>{{$t('+ Add Page')}}</b-btn>
                         </a>
                     </li>
                 </draggable>
@@ -90,7 +90,7 @@
 
             <div class="w-25 border d-flex flex-column">
                 <div class="card-header header-fixed">
-                    Inspector
+                    {{$t('Inspector')}}
                     <div class="float-right dropdown">
                         <button v-if="!validationErrors.length" class="btn btn-sm btn-outline-light" type="button">
                             <i class="fas fa-check-circle text-success"></i>
@@ -103,8 +103,8 @@
                                 href="javascript:void()"
                                 class="dropdown-item" @click="focusInspector(validation)">
                                 <i class="fas fa-times-circle text-danger"></i>
-                                <b>{{validation.item.component}}</b>
-                                {{validation.message}}
+                                <b>{{$t(validation.item.component)}}</b>
+                                {{$t(validation.message)}}
                             </a>
                         </div>
                     </div>
@@ -119,14 +119,14 @@
                 </div>
             </div>
 
-            <b-modal id="addPageModal" @ok="addPage" title="Add New Page">
+            <b-modal id="addPageModal" @ok="addPage" :title="$t('Add New Page')">
                 <form-input v-model="addPageName"
-                            label="Page Name"
-                            helper="The name of the new page to add"></form-input>
+                            :label="$t('Page Name')"
+                            :helper="$t('The name of the new page to add')"></form-input>
             </b-modal>
 
-            <b-modal ref="editPageModal" @ok="editPage" title="Edit Page Title">
-                <form-input v-model="editPageName" label="Page Name" helper="The new name of the page"></form-input>
+            <b-modal ref="editPageModal" @ok="editPage" :title="$t('Edit Page Title')">
+                <form-input v-model="editPageName" :label="$t('Page Name')" :helper="$t('The new name of the page')"></form-input>
             </b-modal>
 
             <b-modal ref="confirm"
@@ -136,8 +136,8 @@
                      @cancel="hideConfirmModal"
                      cancel-variant="btn btn-outline-secondary"
                      ok-variant="btn btn-secondary ml-2">
-                <p>{{confirmMessage}}</p>
-                <div slot="modal-ok">Save</div>
+                <p>{{$t(confirmMessage)}}</p>
+                <div slot="modal-ok">{{$t('Save')}}</div>
             </b-modal>
         </div>
     </div>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -180,6 +180,7 @@
     FormRadioButtonGroup,
     FormDatePicker
   } from "@processmaker/vue-form-elements/src/components";
+import { constants } from 'fs';
 
   export default {
     mixins: [HasColorProperty],
@@ -346,8 +347,16 @@
           inspector: JSON.parse(JSON.stringify(control.inspector)),
           component: control.component,
           "editor-component": control["editor-component"],
-          label: control.label
+          label: control.label,
         };
+
+        copy.config.label = this.$t(copy.config.label)
+        if (copy.config.options) {
+          for (var io in copy.config.options) {
+            copy.config.options[io].content = this.$t(copy.config.options[io].content)
+          }
+        }
+
         // If it's a container, let's add an items property, with the default of items in the control
         if (control.container) {
           copy["items"] = JSON.parse(JSON.stringify(control.items));

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -224,7 +224,8 @@
           }
         ],
         confirmMessage: '',
-        pageDelete: 0
+        pageDelete: 0,
+        translated: [],
       };
     },
     computed: {
@@ -272,6 +273,10 @@
         this.inspection = {};
       },
       inspection(e) {
+        if (this.translated.includes(e)) {
+          // already translated, don't translate again!
+          return
+        }
         for (var i in e.inspector) {
           e.inspector[i].config.label = this.$t(e.inspector[i].config.label)
           e.inspector[i].config.helper = this.$t(e.inspector[i].config.helper)
@@ -281,6 +286,7 @@
             }
           }
         }
+        this.translated.push(e);
       }
     },
     methods: {

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -103,7 +103,7 @@
                                 href="javascript:void()"
                                 class="dropdown-item" @click="focusInspector(validation)">
                                 <i class="fas fa-times-circle text-danger"></i>
-                                <b>{{$t(validation.item.component)}}</b>
+                                <b>{{$t(validation.item.label)}}</b>
                                 {{$t(validation.message)}}
                             </a>
                         </div>

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,15 @@ import Vue from 'vue'
 import App from './App.vue'
 Vue.config.productionTip = false;
 import '@fortawesome/fontawesome-free/css/all.min.css';
+import i18next from 'i18next';
+import VueI18Next from '@panter/vue-i18next';
+
+// Allow strings to be wrapped in $t(...) for translating
+// outside this package. This standalone app just returns
+// the English string
+Vue.use(VueI18Next)
+i18next.init({lng: 'en'})
+Vue.mixin({ i18n: new VueI18Next(i18next) })
 
 new Vue({
   render: h => h(App)


### PR DESCRIPTION
Fixes #137 

Known issue: errors from our frontend validation library, validatorjs, are not translated. [They mention there is some support](https://github.com/skaterdav85/validatorjs#language-support) but its not vue-i18next. Maybe this can be fixed with custom messages but we would have to manually add all of them