### PR TITLE
Add config data interpolation for form-text component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,10 +5,10 @@
         <div class="row">
           <div class="col">
             <b-button-group size="sm">
-              <b-button :variant="displayBuilder? 'outline-secondary' : 'secondary'" @click="mode = 'editor'">
+              <b-button :variant="displayBuilder? 'secondary' : 'outline-secondary'" @click="mode = 'editor'">
                 <i class="fas fa-drafting-compass pr-1"></i>{{ $t('Design') }}
               </b-button>
-              <b-button :variant="!displayBuilder? 'outline-secondary' : 'secondary'" @click="mode = 'preview'">
+              <b-button :variant="!displayBuilder? 'secondary' : 'outline-secondary'" @click="mode = 'preview'">
                 <i class="fas fa-cogs pr-1"></i>{{ $t('Preview') }}
               </b-button>
             </b-button-group>

--- a/src/components/renderer/form-text.vue
+++ b/src/components/renderer/form-text.vue
@@ -29,10 +29,14 @@ export default {
       };
     },
     rendered() {
+      if (!this.validationData) {
+        return this.label;
+      }
+
       try {
         return Mustache.render(this.label, this.validationData);
-      } catch (e) {
-        return this.$t(this.label);
+      } catch (error) {
+        return this.label;
       }
     }
   }


### PR DESCRIPTION
Fixes #151.

How to test:
1. Select `Preview` and add some data under `Data Input`, e.g. `{ "name": "Rob" }`.
2. Select `Editor`, drag a `Text` component onto the form, and select it.
3. In the `Inspector`, add something like `Hello, {{name}}.` for `Text Content`.
4. The component in the `Preview` window should show `Hello, Rob.`, instead of just `Hello, .`
5. Repeat steps 2-4 above for the `Rich Text` component.

Blocked until https://github.com/ProcessMaker/vue-form-elements/pull/33 is merged and published. That PR is required to add the interpolation to the `Rich Text` component.