### PR TITLE
Removing “drag element here” card

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -103,6 +103,11 @@
                         </button>
                     </div>
                 </div>
+                <div class="card">
+                    <div class="card-body text-center">
+                        {{ $t('Drag an element here') }}
+                    </div>
+                </div>
             </draggable>
         </div>
         <div class="form-builder__inspector col-3 shadow-sm pl-0 pr-0 mr-3 card">

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -103,11 +103,6 @@
                         </button>
                     </div>
                 </div>
-                <div class="card">
-                    <div class="card-body text-center">
-                        {{ $t('Drag an element here') }}
-                    </div>
-                </div>
             </draggable>
         </div>
         <div class="form-builder__inspector col-3 shadow-sm pl-0 pr-0 mr-3 card">

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -107,6 +107,11 @@
                           </button>
                         </div>
                     </div>
+                    <div class="card">
+                      <div  class="card-body text-center">
+                        Drag an element here
+                      </div>
+                    </div>
                 </draggable>
             </div>
             <div class="form-builder__inspector col-3 shadow-sm pl-0 pr-0 mr-3 card">

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -107,11 +107,6 @@
                           </button>
                         </div>
                     </div>
-                    <div class="card">
-                      <div  class="card-body text-center">
-                        Drag an element here
-                      </div>
-                    </div>
                 </draggable>
             </div>
             <div class="form-builder__inspector col-3 shadow-sm pl-0 pr-0 mr-3 card">

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -115,9 +115,6 @@
             <div v-if="!element.config.interactive" class="mask"></div>
           </div>
         </div>
-        <div class="card">
-          <div class="card-body text-center">{{ $t('Drag an element here') }}</div>
-        </div>
       </draggable>
     </b-col>
 


### PR DESCRIPTION
## Changes
- Removes the "Drag an element here" card from the draggable area until a better solution can be implemented

Closes #170.