### PR TITLE
Add selected state to multi-column

### DIFF
--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -1,6 +1,6 @@
 <template>
     <div :class="classContainer">
-        <div class="container-fluid">
+        <div>
             <div class="row">
                 <template v-for="(item, index) in items">
                     <draggable :class="classColumn(index)"

--- a/src/components/renderer/form-multi-column.vue
+++ b/src/components/renderer/form-multi-column.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="form-group">
-        <div class="container-fluid">
+        <div>
             <div class="row">
                 <template v-for="(item, key) in items">
 

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -79,8 +79,22 @@
           :key="index"
           @click="inspect(element)"
         >
-          <div v-if="element.container" @click="inspect(element)">
+          <div v-if="element.container" @click="inspect(element)" class="card">
+            <div
+              v-if="selected === element"
+              class="card-header form-element-header d-flex align-items-center"
+            >
+              <i class="fas fa-arrows-alt-v mr-1"/>
+              {{ element.config.name || element.label || $t('Field Name') }}
+              <button
+                class="btn btn-sm btn-danger ml-auto"
+                @click="deleteItem(index)">
+                <i class="far fa-trash-alt text-light"/>
+              </button>
+            </div>
+
             <component
+              class="card-body m-0 pb-4 pt-4"
               :class="elementCssClass(element)"
               @inspect="inspect"
               :selected="selected"

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -94,7 +94,7 @@
             </div>
 
             <component
-              class="card-body m-0 pb-4 pt-4"
+              class="card-body m-2 mr-3 ml-3 pt-3"
               :class="elementCssClass(element)"
               @inspect="inspect"
               :selected="selected"


### PR DESCRIPTION
- Multi-column element did not have the classes attached

**Screen Builder Stand Alone**
https://drive.google.com/open?id=16C_oWwyEPobwM_jvxYdUF0n6DqUbyWSz

**Spark Screen Builder**
https://drive.google.com/open?id=10Q-MLnN0Bhx5iY1aJEI2UO2BelIaoJHq

In type display, multi-column is broken in this branch, but is fixed in this PR https://github.com/ProcessMaker/spark/pull/1852

 Fixes #182 
