### PR TITLE
Preview Inspector UI

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -356,8 +356,6 @@ import Validator from "validatorjs";
       max-width: 265px;
     }
 
-
-
     .data-collapse {
       height: 300px;
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,7 +39,7 @@
 
         <!-- Preview -->
         <b-row class="h-100" id="preview" v-show="displayPreview">
-          <b-col cols="8" class="overflow-auto h-100 border rounded">
+          <b-col class="overflow-auto h-100 border rounded mr-4">
             <vue-form-renderer ref="renderer"
               v-model="previewData"
               class="p-3 overflow-auto"
@@ -50,36 +50,41 @@
               v-on:css-errors="cssErrors = $event"/>
           </b-col>
 
-          <b-col cols="4" class="overflow-hidden h-100 pr-0 pl-4">
-            <b-card no-body class="p-0">
+          <b-col class="overflow-hidden h-100 preview-inspector p-0">
+            <b-card no-body class="p-0 h-100">
               <b-card-header class="stick-top">
                 Inspector
               </b-card-header>
 
-              <b-card-body class="p-0">
-                <b-button v-b-toggle.dataInput variant="outline"
-                  class="text-left card-header d-flex align-items-center w-100"
-                  @click="showDataInput = !showDataInput">
-                  <i class="fas fa-file-import mr-2"></i>
-                    {{ $t('Data Input') }}
-                  <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataInput }"></i>
-                </b-button>
+              <b-card-body class="p-0 h-100">
+                <div class="h-auto">
+                  <b-button v-b-toggle.dataInput variant="outline"
+                    class="text-left card-header d-flex align-items-center w-100"
+                    @click="showDataInput = !showDataInput">
+                    <i class="fas fa-file-import mr-2"></i>
+                      {{ $t('Data Input') }}
+                    <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataInput }"></i>
+                  </b-button>
 
-                <b-collapse id="dataInput" visible class="overflow-auto">
-                  <form-text-area class="data-height h-100 dataInput"  v-model="previewInput"></form-text-area>
-                </b-collapse>
+                  <b-collapse id="dataInput" visible class="overflow-auto">
+                    <form-text-area class="data-height dataInput" v-model="previewInput" rows="10"></form-text-area>
+                  </b-collapse>
+                </div>
 
-                <b-button v-b-toggle.dataPreview variant="outline"
-                  class="text-left card-header d-flex align-items-center w-100"
-                  @click="showDataPreview = !showDataPreview">
-                  <i class="fas fa-file-code mr-2"></i>
-                    {{ $t('Data Preview') }}
-                  <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataPreview }"></i>
-                </b-button>
+                <div class="h-auto">
+                  <b-button v-b-toggle.dataPreview variant="outline"
+                    class="text-left card-header d-flex align-items-center w-100 border-top"
+                    @click="showDataPreview = !showDataPreview">
+                    <i class="fas fa-file-code mr-2"></i>
+                      {{ $t('Data Preview') }}
+                    <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataPreview }"></i>
+                  </b-button>
 
-                <b-collapse id="dataPreview" visible class="mt-2 overflow-auto">
-                  <vue-json-pretty  :data="previewData" class="p-2 data-height"></vue-json-pretty>
-                </b-collapse>
+                  <b-collapse id="dataPreview" visible class="mt-2 overflow-auto">
+                    <vue-json-pretty  :data="previewData" class="p-2 h-50"></vue-json-pretty>
+                  </b-collapse>
+                </div>
+
               </b-card-body>
             </b-card>
           </b-col>
@@ -337,10 +342,15 @@ import Validator from "validatorjs";
     }
 
     .data-height {
-      max-height: 200px;
+      max-height: 50%;
+      min-height: 50%;
     }
 
     .list-group-item:last-child {
       border-bottom: 1px solid #dfdfdf !important;
+    }
+
+    .preview-inspector {
+      max-width: 265px;
     }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -57,8 +57,7 @@
               </b-card-header>
 
               <b-card-body class="p-0 overflow-auto">
-
-                  <b-button v-b-toggle.data-input variant="outline"
+                  <b-button variant="outline"
                     class="text-left card-header d-flex align-items-center w-100 shadow-none"
                     @click="showDataInput = !showDataInput">
                     <i class="fas fa-file-import mr-2"></i>
@@ -66,13 +65,11 @@
                     <i class="fas ml-auto" :class="showDataInput ? 'fa-angle-right' : 'fa-angle-down'"></i>
                   </b-button>
 
-                  <b-collapse id="data-input" visible>
+                  <b-collapse v-model="showDataInput" id="showDataInput">
                     <form-text-area class="data-input mb-0 data-collapse" v-model="previewInput"></form-text-area>
                   </b-collapse>
 
-
-
-                  <b-button v-b-toggle.dataPreview variant="outline"
+                  <b-button variant="outline"
                     class="text-left card-header d-flex align-items-center w-100 shadow-none"
                     data-toggle="collapse"
                     @click="showDataPreview = !showDataPreview">
@@ -81,8 +78,8 @@
                     <i class="fas ml-auto" :class="showDataPreview ? 'fa-angle-right' : 'fa-angle-down'"></i>
                   </b-button>
 
-                  <b-collapse id="dataPreview" visible class="mt-2">
-                    <vue-json-pretty  :data="previewData" class="p-2 data-collapse"></vue-json-pretty>
+                  <b-collapse v-model="showDataPreview" id="showDataPreview" class="mt-2">
+                    <vue-json-pretty :data="previewData" class="p-2 data-collapse"></vue-json-pretty>
                   </b-collapse>
 
               </b-card-body>
@@ -179,8 +176,8 @@ import Validator from "validatorjs";
         cssErrors: '',
         showValidationErrors: false,
         toggleValidation: true,
-        showDataPreview: false,
-        showDataInput: false,
+        showDataPreview: true,
+        showDataInput: true,
       };
     },
     components: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -343,11 +343,6 @@ import Validator from "validatorjs";
       border: 1px solid green;
     }
 
-    .data-height {
-      max-height: 50%;
-      min-height: 50%;
-    }
-
     .list-group-item:last-child {
       border-bottom: 1px solid #dfdfdf !important;
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -56,35 +56,32 @@
                 Inspector
               </b-card-header>
 
-              <b-card-body class="p-0 h-100">
-                <div class="h-auto">
+              <b-card-body class="p-0 overflow-auto">
                   <b-button v-b-toggle.dataInput variant="outline"
-                    class="text-left card-header d-flex align-items-center w-100"
+                    class="text-left card-header d-flex align-items-center w-100 shadow-none"
                     @click="showDataInput = !showDataInput">
                     <i class="fas fa-file-import mr-2"></i>
                       {{ $t('Data Input') }}
                     <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataInput }"></i>
                   </b-button>
 
-                  <b-collapse id="dataInput" visible class="overflow-auto">
-                    <form-text-area class="data-height dataInput" v-model="previewInput" rows="10"></form-text-area>
+                  <b-collapse id="dataInput" visible class="">
+                    <form-text-area class="dataInput mb-0" v-model="previewInput" rows="10"></form-text-area>
                   </b-collapse>
-                </div>
 
-                <div class="h-auto">
+
                   <b-button v-b-toggle.dataPreview variant="outline"
-                    class="text-left card-header d-flex align-items-center w-100 border-top"
+                    class="text-left card-header d-flex align-items-center w-100 border-top shadow-none"
+                    data-toggle="collapse"
                     @click="showDataPreview = !showDataPreview">
                     <i class="fas fa-file-code mr-2"></i>
                       {{ $t('Data Preview') }}
                     <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataPreview }"></i>
                   </b-button>
 
-                  <b-collapse id="dataPreview" visible class="mt-2 overflow-auto">
-                    <vue-json-pretty  :data="previewData" class="p-2 h-50"></vue-json-pretty>
+                  <b-collapse id="dataPreview" visible class="mt-2">
+                    <vue-json-pretty  :data="previewData" class="p-2"></vue-json-pretty>
                   </b-collapse>
-                </div>
-
               </b-card-body>
             </b-card>
           </b-col>

--- a/src/App.vue
+++ b/src/App.vue
@@ -57,21 +57,21 @@
               </b-card-header>
 
               <b-card-body class="p-0 overflow-auto">
-                  <div class="h-50">
-                    <b-button v-b-toggle.dataInput variant="outline"
-                      class="text-left card-header d-flex align-items-center w-100 shadow-none"
-                      @click="showDataInput = !showDataInput">
-                      <i class="fas fa-file-import mr-2"></i>
-                        {{ $t('Data Input') }}
-                      <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataInput }"></i>
-                    </b-button>
+                <div class="h-50">
+                  <b-button v-b-toggle.dataInput variant="outline"
+                    class="text-left card-header d-flex align-items-center w-100 shadow-none"
+                    @click="showDataInput = !showDataInput">
+                    <i class="fas fa-file-import mr-2"></i>
+                      {{ $t('Data Input') }}
+                    <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataInput }"></i>
+                  </b-button>
 
                   <b-collapse id="dataInput" visible class="">
                     <form-text-area class="dataInput mb-0" v-model="previewInput" rows="12"></form-text-area>
                   </b-collapse>
-                  </div>
+                </div>
 
-                  <div class="h-50">
+                <div class="h-50">
                   <b-button v-b-toggle.dataPreview variant="outline"
                     class="text-left card-header d-flex align-items-center w-100 shadow-none"
                     data-toggle="collapse"
@@ -84,7 +84,7 @@
                   <b-collapse id="dataPreview" visible class="mt-2">
                     <vue-json-pretty  :data="previewData" class="p-2"></vue-json-pretty>
                   </b-collapse>
-                  </div>
+                </div>
               </b-card-body>
             </b-card>
           </b-col>

--- a/src/App.vue
+++ b/src/App.vue
@@ -71,7 +71,7 @@
 
 
                   <b-button v-b-toggle.dataPreview variant="outline"
-                    class="text-left card-header d-flex align-items-center w-100 border-top shadow-none"
+                    class="text-left card-header d-flex align-items-center w-100 shadow-none"
                     data-toggle="collapse"
                     @click="showDataPreview = !showDataPreview">
                     <i class="fas fa-file-code mr-2"></i>

--- a/src/App.vue
+++ b/src/App.vue
@@ -57,19 +57,21 @@
               </b-card-header>
 
               <b-card-body class="p-0 overflow-auto">
-                  <b-button v-b-toggle.dataInput variant="outline"
-                    class="text-left card-header d-flex align-items-center w-100 shadow-none"
-                    @click="showDataInput = !showDataInput">
-                    <i class="fas fa-file-import mr-2"></i>
-                      {{ $t('Data Input') }}
-                    <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataInput }"></i>
-                  </b-button>
+                  <div class="h-50">
+                    <b-button v-b-toggle.dataInput variant="outline"
+                      class="text-left card-header d-flex align-items-center w-100 shadow-none"
+                      @click="showDataInput = !showDataInput">
+                      <i class="fas fa-file-import mr-2"></i>
+                        {{ $t('Data Input') }}
+                      <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataInput }"></i>
+                    </b-button>
 
                   <b-collapse id="dataInput" visible class="">
-                    <form-text-area class="dataInput mb-0" v-model="previewInput" rows="10"></form-text-area>
+                    <form-text-area class="dataInput mb-0" v-model="previewInput" rows="12"></form-text-area>
                   </b-collapse>
+                  </div>
 
-
+                  <div class="h-50">
                   <b-button v-b-toggle.dataPreview variant="outline"
                     class="text-left card-header d-flex align-items-center w-100 shadow-none"
                     data-toggle="collapse"
@@ -82,6 +84,7 @@
                   <b-collapse id="dataPreview" visible class="mt-2">
                     <vue-json-pretty  :data="previewData" class="p-2"></vue-json-pretty>
                   </b-collapse>
+                  </div>
               </b-card-body>
             </b-card>
           </b-col>
@@ -349,5 +352,9 @@ import Validator from "validatorjs";
 
     .preview-inspector {
       max-width: 265px;
+    }
+
+    textarea.form-control {
+      padding-bottom: 11px;
     }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -57,34 +57,34 @@
               </b-card-header>
 
               <b-card-body class="p-0 overflow-auto">
-                <div class="h-50">
-                  <b-button v-b-toggle.dataInput variant="outline"
+
+                  <b-button v-b-toggle.data-input variant="outline"
                     class="text-left card-header d-flex align-items-center w-100 shadow-none"
                     @click="showDataInput = !showDataInput">
                     <i class="fas fa-file-import mr-2"></i>
                       {{ $t('Data Input') }}
-                    <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataInput }"></i>
+                    <i class="fas ml-auto" :class="showDataInput ? 'fa-angle-right' : 'fa-angle-down'"></i>
                   </b-button>
 
-                  <b-collapse id="dataInput" visible class="">
-                    <form-text-area class="dataInput mb-0" v-model="previewInput" rows="12"></form-text-area>
+                  <b-collapse id="data-input" visible>
+                    <form-text-area class="data-input mb-0 data-collapse" v-model="previewInput"></form-text-area>
                   </b-collapse>
-                </div>
 
-                <div class="h-50">
+
+
                   <b-button v-b-toggle.dataPreview variant="outline"
                     class="text-left card-header d-flex align-items-center w-100 shadow-none"
                     data-toggle="collapse"
                     @click="showDataPreview = !showDataPreview">
                     <i class="fas fa-file-code mr-2"></i>
                       {{ $t('Data Preview') }}
-                    <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataPreview }"></i>
+                    <i class="fas ml-auto" :class="showDataPreview ? 'fa-angle-right' : 'fa-angle-down'"></i>
                   </b-button>
 
                   <b-collapse id="dataPreview" visible class="mt-2">
-                    <vue-json-pretty  :data="previewData" class="p-2"></vue-json-pretty>
+                    <vue-json-pretty  :data="previewData" class="p-2 data-collapse"></vue-json-pretty>
                   </b-collapse>
-                </div>
+
               </b-card-body>
             </b-card>
           </b-col>
@@ -329,8 +329,13 @@ import Validator from "validatorjs";
       right: 0;
     }
 
-    .dataInput {
+    .data-input {
       margin-top: -25px;
+
+      textarea.form-control {
+        height: calc(100% - 25px);
+        resize: none;
+      }
     }
 
     .card-header {
@@ -354,7 +359,9 @@ import Validator from "validatorjs";
       max-width: 265px;
     }
 
-    textarea.form-control {
-      padding-bottom: 11px;
+
+
+    .data-collapse {
+      height: 300px;
     }
 </style>


### PR DESCRIPTION
- Preview Inspector uses the full height of the card
- Data input / preview take 50% of the inspector container

<img width="1680" alt="Screen Shot 2019-05-22 at 1 29 17 PM" src="https://user-images.githubusercontent.com/26545455/58195300-a1eac600-7c95-11e9-9ed0-39980ba65aeb.png">

https://drive.google.com/open?id=1XECBNU_X86rXZcLReKm7eHUL5bn73QrH

Fixes #172 , #171 