### PR TITLE
Fix bottom border on dragging form control 

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -468,16 +468,6 @@ export default {
 <style lang="scss" scoped>
 $header-bg: #f7f7f7;
 
-.form-builder__designer {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  padding: 0 1.5rem;
-
-  &--select {
-    border-radius: 5px !important;
-  }
-}
 .control-icon {
   width: 30px;
   font-size: 20px;

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -575,5 +575,6 @@ $header-bg: #f7f7f7;
 
 .form-elements-list > .list-group-item {
   margin-bottom: 0;
+  border-radius: 0.25rem;
 }
 </style>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -68,7 +68,7 @@
         <hr class="w-100">
       </b-input-group>
       <draggable
-        class="form-elements-list"
+        ghost-class="form-control-ghost"
         :value="config[currentPage].items"
         @input="updateConfig"
         :options="{group: {name: 'controls'}}"
@@ -573,7 +573,7 @@ $header-bg: #f7f7f7;
   max-width: 265px;
 }
 
-.form-elements-list > .list-group-item {
+.form-control-ghost {
   margin-bottom: 0;
   border-radius: 0.25rem;
 }

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -68,6 +68,7 @@
         <hr class="w-100">
       </b-input-group>
       <draggable
+        class="form-elements-list"
         :value="config[currentPage].items"
         @input="updateConfig"
         :options="{group: {name: 'controls'}}"
@@ -580,5 +581,9 @@ $header-bg: #f7f7f7;
 
 .inspector-column {
   max-width: 265px;
+}
+
+.form-elements-list > .list-group-item {
+  margin-bottom: 0;
 }
 </style>


### PR DESCRIPTION
Fixes #174.

Ensures the bug, [as described in the issue](https://github.com/ProcessMaker/spark-screen-builder/issues/174#issuecomment-494938340), is no longer present.

The issue was that `draggable` was cloning the control element to use as the preview in the form elements list, and the cloned element was a list group item. List group items, by default, only render with a bottom border if they are at the bottom of the list, and also only have rounded top and bottom borders if they are at the top or bottom of the list, respectively.

**Video of fix:**
https://www.dropbox.com/s/lwvg986iqb1zoci/bottom-border-fixed.mov?dl=0
