### PR TITLE
Preview Page Will Start with First Form

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,6 +45,7 @@
               class="p-3 overflow-auto"
               @submit="previewSubmit"
               :config="config"
+              :mode="mode"
               :computed="computed"
               :custom-css="customCSS"
               v-on:css-errors="cssErrors = $event"/>

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -59,7 +59,7 @@ Vue.use(VueDeepSet);
 
 export default {
   name: "VueFormRenderer",
-  props: ["config", "data", "page", "computed", "customCss"],
+  props: ["config", "data", "page", "computed", "customCss", "mode"],
   model: {
     prop: "data",
     event: "update"
@@ -99,6 +99,9 @@ export default {
     };
   },
   watch: {
+    mode() {
+      this.currentPage = 0;
+    },
     data() {
       this.transientData = JSON.parse(JSON.stringify(this.data));
     },


### PR DESCRIPTION
**How to Test**
- Create new form page
- On `default page` (first form) drag a navigation component and set destination to any other page than the default page
- Click Preview, navigate to another page
- Toggle between builder and preview

**Expected**
- Toggling between preview and builder, the first form page will be set as the first one visible 

**Stand Alone**
https://drive.google.com/open?id=1IT2t5Ne6_CqU3xxX6BrWWo9pMZE_FKj7

**Spark Screen Builder**
Will address in this issue (https://github.com/ProcessMaker/spark/issues/1881) and have its own separate PR(https://github.com/ProcessMaker/spark/pull/1883) in spark repo.

Fixes #205 