### PR TITLE
Replace textarea component for monaco editor 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -66,7 +66,7 @@
                   </b-button>
 
                   <b-collapse v-model="showDataInput" id="showDataInput">
-                    <form-text-area class="data-input mb-0 data-collapse" v-model="previewInput"></form-text-area>
+                    <monaco-editor :options="monacoOptions" :minimap="{ enabled:false }" class="data-collapse" v-model="previewInput" language="json"/>
                   </b-collapse>
 
                   <b-button variant="outline"
@@ -142,6 +142,7 @@
   import VueFormBuilder from "./components/vue-form-builder.vue";
   import VueFormRenderer from "./components/vue-form-renderer.vue";
   import VueJsonPretty from 'vue-json-pretty';
+  import MonacoEditor from "vue-monaco";
 
   // Bring in our initial set of controls
   import controlConfig from "./form-builder-controls";
@@ -178,6 +179,11 @@ import Validator from "validatorjs";
         toggleValidation: true,
         showDataPreview: true,
         showDataInput: true,
+        monacoOptions: {
+          automaticLayout: true,
+          lineNumbers: 'off',
+          minimap: false,
+      },
       };
     },
     components: {
@@ -186,7 +192,8 @@ import Validator from "validatorjs";
       VueFormBuilder,
       VueFormRenderer,
       VueJsonPretty,
-      FormTextArea
+      FormTextArea,
+      MonacoEditor,
     },
     watch: {
       mode(mode) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -147,9 +147,6 @@
   // Bring in our initial set of controls
   import controlConfig from "./form-builder-controls";
   import globalProperties from "./global-properties";
-  import {
-    FormTextArea,
-  } from "@processmaker/vue-form-elements";
 
 import Validator from "validatorjs";
 
@@ -192,7 +189,6 @@ import Validator from "validatorjs";
       VueFormBuilder,
       VueFormRenderer,
       VueJsonPretty,
-      FormTextArea,
       MonacoEditor,
     },
     watch: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -66,7 +66,7 @@
                   </b-button>
 
                   <b-collapse v-model="showDataInput" id="showDataInput">
-                    <monaco-editor :options="monacoOptions" :minimap="{ enabled:false }" class="data-collapse" v-model="previewInput" language="json"/>
+                    <monaco-editor :options="monacoOptions" class="data-collapse" v-model="previewInput" language="json"/>
                   </b-collapse>
 
                   <b-button variant="outline"

--- a/src/App.vue
+++ b/src/App.vue
@@ -333,15 +333,6 @@ import Validator from "validatorjs";
       right: 0;
     }
 
-    .data-input {
-      margin-top: -25px;
-
-      textarea.form-control {
-        height: calc(100% - 25px);
-        resize: none;
-      }
-    }
-
     .card-header {
       border-radius: 0 !important;
     }

--- a/vue.config.js
+++ b/vue.config.js
@@ -6,8 +6,8 @@ module.exports = {
   configureWebpack: {
     plugins: [
       new MonocoEditorPlugin({
-        languages: ['javascript', 'typescript', 'css']
-      })
+        languages: ['javascript', 'css', 'json']
+      }),
     ],
     resolve: {
       modules: [


### PR DESCRIPTION
**Changes**
- removed form text area component 
- use monaco editor instead

**To Test**
- Navigate to the preview view
- type an json object

**Expected**
- JSON has formatting and syntax highlighting 

**Screen Capture**
https://drive.google.com/open?id=1cmEBK2WghffeV1wtonTrHq8iOA2galZO

- Spark application has a separate PR(https://github.com/ProcessMaker/spark/pull/1885) in the spark repo to use the Monaco Editor

Fixes #173 