### PR TITLE
Fix preview and radio group checked state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@processmaker/spark-screen-builder",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -980,9 +980,10 @@
       }
     },
     "@processmaker/vue-form-elements": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@processmaker/vue-form-elements/-/vue-form-elements-0.9.0.tgz",
-      "integrity": "sha512-trAfD2WIjBOrlOiUX6MvNk/Xft02IsAJLO3YtU6pqwFE6HsNKl4gw/M98Io94c/ITSJMcb+MupajhaKPdGYe2w==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@processmaker/vue-form-elements/-/vue-form-elements-0.10.0.tgz",
+      "integrity": "sha512-pElasOc1P7AnsGZpcKv0m8n0pZm+/a7niZ4MZ9yB6TqsQqwtAXgmne3jOfTrjxd3Pw6fH5z8y+wWNndJYL1xJg==",
+      "dev": true,
       "requires": {
         "@tinymce/tinymce-vue": "^2.0.0",
         "bootstrap": "^4.2.1",
@@ -1045,6 +1046,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tinymce/tinymce-vue/-/tinymce-vue-2.0.0.tgz",
       "integrity": "sha512-oUl8r1WvoLsy1NxpFMPNa8hZohkha6biNGLBAhtWUEIsqnmAhvosTPdVj2uroAlK7rjOcDTOy2jIkuNOsLuvtA==",
+      "dev": true,
       "requires": {
         "vue": "^2.5.17"
       }
@@ -2981,7 +2983,8 @@
     "bootstrap": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
-      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag==",
+      "dev": true
     },
     "bootstrap-vue": {
       "version": "2.0.0-rc.16",
@@ -10003,7 +10006,8 @@
     "jquery": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+      "dev": true
     },
     "js-base64": {
       "version": "2.5.1",
@@ -10507,9 +10511,10 @@
       }
     },
     "luxon": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.13.2.tgz",
-      "integrity": "sha512-U7i2AE+/VWeB8PZZkIeEcxJCZvBA8LegCHufaIFYx3qRQdw2UJw3fuaL/Fqi9Q+2MeFYu+gYqIzr5hWOvAMHBQ=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.15.0.tgz",
+      "integrity": "sha512-HIpK4zIonObWHj9UC80ElykmM/0jTuuXcbPYBYbDGZ3Cq2bL9rACcmppoc6zm5JnmHpnK5bRMIp8/+ei4O0y2Q==",
+      "dev": true
     },
     "make-dir": {
       "version": "2.1.0",
@@ -11833,7 +11838,8 @@
     "popper.js": {
       "version": "1.14.7",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.7.tgz",
-      "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ=="
+      "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ==",
+      "dev": true
     },
     "portfinder": {
       "version": "1.0.20",
@@ -14684,9 +14690,10 @@
       "dev": true
     },
     "tinymce": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.0.5.tgz",
-      "integrity": "sha512-3cE7gfufXlbFBz4TMV/nfJtMM+a8J7K5Jy8keEU+T5QIRXcykF5/j7Dd32OXKQczqijy11+ffqM5tnvAbHzo/A=="
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.0.6.tgz",
+      "integrity": "sha512-9/pcrO8awssCrbfSeNzlt2talFO4ZBCxiwWFLTrSOy5kJI4gXKGKHsZzstoyt7cbwbT1cUjLlUiDqW8IgmL6JA==",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -15230,7 +15237,8 @@
     "vue-datetime": {
       "version": "1.0.0-beta.10",
       "resolved": "https://registry.npmjs.org/vue-datetime/-/vue-datetime-1.0.0-beta.10.tgz",
-      "integrity": "sha512-/wJkj95JSzWqH0Ja4JpXX6I+fXo2A34GCtsx00vR5RjNxk3++93rg7G4ZlI3MFo807zH9bIxXfIohbAZgnAWbQ=="
+      "integrity": "sha512-/wJkj95JSzWqH0Ja4JpXX6I+fXo2A34GCtsx00vR5RjNxk3++93rg7G4ZlI3MFo807zH9bIxXfIohbAZgnAWbQ==",
+      "dev": true
     },
     "vue-deepset": {
       "version": "0.6.3",
@@ -15930,7 +15938,8 @@
     "weekstart": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/weekstart/-/weekstart-1.0.0.tgz",
-      "integrity": "sha1-4K7jWNRa2ZgCJUdp17KjTJOA9Tk="
+      "integrity": "sha1-4K7jWNRa2ZgCJUdp17KjTJOA9Tk=",
+      "dev": true
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.6.1",
     "@panter/vue-i18next": "^0.15.0",
-    "@processmaker/vue-form-elements": "^0.10.0",
     "babel-loader": "^7.1.5",
     "css-tree": "^1.0.0-alpha.29",
     "expr-eval": "^1.2.2",
@@ -40,6 +39,7 @@
     "vuetable-2": "^1.7.5"
   },
   "devDependencies": {
+    "@processmaker/vue-form-elements": "^0.10.0",
     "@babel/core": "^7.4.3",
     "@vue/cli-plugin-babel": "^3.0.0-rc.9",
     "@vue/cli-plugin-eslint": "^3.0.0-rc.9",
@@ -56,6 +56,7 @@
     "vuex": "^3.1.0"
   },
   "peerDependencies": {
+    "@processmaker/vue-form-elements": "^0.10.0",
     "bootstrap": "^4.3.1",
     "bootstrap-vue": "^2.0.0-rc.14",
     "vuex": "^3.1.0"

--- a/src/components/editor/index.js
+++ b/src/components/editor/index.js
@@ -1,0 +1,1 @@
+export { default as MultiColumn } from './multi-column.vue';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,32 +1,10 @@
 // Import our components
 import VueFormBuilder from './vue-form-builder'
 import VueFormRenderer from './vue-form-renderer'
-import MultiColumn from './editor/multi-column'
-import OptionsList from './inspector/options-list'
-import PageSelect from './inspector/page-select'
-import FormButton from './renderer/form-button'
-import FormMultiColumn from './renderer/form-multi-column'
-import FormRecordList from './renderer/form-record-list'
-import FormText from './renderer/form-text'
-import ImageUpload from './inspector/image-upload.vue'
+import * as editor from './editor'
+import * as renderer from './renderer'
+import * as inspector from './inspector'
 import FormBuilderControls from '../form-builder-controls'
-
-let editor = {
-    MultiColumn
-}
-
-let inspector = {
-    OptionsList,
-    PageSelect,
-    ImageUpload
-}
-
-let renderer = {
-    FormButton,
-    FormMultiColumn,
-    FormRecordList,
-    FormText
-}
 
 // Export our named exports
 export {

--- a/src/components/inspector/index.js
+++ b/src/components/inspector/index.js
@@ -1,0 +1,6 @@
+export { default as ColorSelect } from './color-select';
+export { default as ContainerColumns } from './container-columns';
+export { default as FormMultiselect } from './form-multiselect';
+export { default as ImageUpload } from './image-upload.vue';
+export { default as OptionsList } from './options-list';
+export { default as PageSelect } from './page-select';

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -76,16 +76,12 @@
 
 
 <script>
-  // import bModal from "bootstrap-vue/es/components/modal/modal";
-  import VueFormRenderer from "../vue-form-renderer";
   import Vuetable from "vuetable-2/src/components/Vuetable";
   import VuetablePagination from "vuetable-2/src/components/VuetablePagination";
 
   export default {
     name: "FormRecordList",
     components: {
-      // bModal,
-      VueFormRenderer,
       Vuetable,
       VuetablePagination
     },

--- a/src/components/renderer/index.js
+++ b/src/components/renderer/index.js
@@ -1,0 +1,5 @@
+export { default as FormButton } from './form-button';
+export { default as FormImage } from './form-image';
+export { default as FormMultiColumn } from './form-multi-column';
+export { default as FormRecordList } from './form-record-list';
+export { default as FormText } from './form-text.vue';

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -218,22 +218,10 @@
 <script>
 import Vue from "vue";
 import draggable from "vuedraggable";
-
-import FormMultiselect from "./inspector/form-multiselect";
-import OptionsList from "./inspector/options-list";
-import ContainerColumns from "./inspector/container-columns";
-import PageSelect from "./inspector/page-select";
-import ImageUpload from "./inspector/image-upload";
-import ColorSelect from "./inspector/color-select";
 import HasColorProperty from "../mixins/HasColorProperty";
-
-import FormMultiColumn from "./renderer/form-multi-column";
-import MultiColumn from "./editor/multi-column";
-
-import FormText from "./renderer/form-text";
-import FormButton from "./renderer/form-button";
-import FormRecordList from "./renderer/form-record-list";
-import FormImage from "./renderer/form-image";
+import * as editor from './editor';
+import * as renderer from './renderer';
+import * as inspector from './inspector';
 
 import BootstrapVue from "bootstrap-vue";
 
@@ -274,25 +262,22 @@ export default {
     draggable,
     FormInput,
     FormSelect,
-    FormMultiselect,
-    OptionsList,
-    ContainerColumns,
     FormCheckbox,
     FormRadioButtonGroup,
     FormTextArea,
-    FormText,
-    FormButton,
-    PageSelect,
-    MultiColumn,
-    FormMultiColumn,
     FormDatePicker,
-    FormRecordList,
-    FormImage,
-    ImageUpload,
-    ColorSelect,
-    FormHtmlEditor
+    FormHtmlEditor,
+    ...editor,
+    ...inspector,
+    ...renderer
   },
   data() {
+    const config = this.initialConfig || defaultConfig;
+
+    if (this.title) {
+      config[0].name = this.title;
+    }
+
     return {
       currentPage: 0,
       selected: null,
@@ -304,7 +289,7 @@ export default {
       addPageName: "",
       editPageIndex: null,
       editPageName: "",
-      config: this.initialConfig || defaultConfig,
+      config,
       confirmMessage: "",
       pageDelete: 0,
       translated: [],
@@ -440,11 +425,6 @@ export default {
       return copy;
     }
   },
-  mounted() {
-    if (this.title) {
-      this.config[0].name = this.title;
-    }
-  }
 };
 </script>
 

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -45,6 +45,18 @@ import Vue from "vue";
 import * as VueDeepSet from "vue-deepset";
 import _ from "lodash";
 import HasColorProperty from "../mixins/HasColorProperty";
+import * as editor from './editor';
+import * as renderer from './renderer';
+import * as inspector from './inspector';
+import {
+  FormInput,
+  FormSelect,
+  FormTextArea,
+  FormCheckbox,
+  FormRadioButtonGroup,
+  FormDatePicker,
+  FormHtmlEditor
+} from "@processmaker/vue-form-elements";
 
 var Parser = require("expr-eval").Parser;
 var csstree = require("css-tree");
@@ -65,6 +77,18 @@ export default {
     event: "update"
   },
   mixins: [HasColorProperty],
+  components: {
+    FormInput,
+    FormSelect,
+    FormCheckbox,
+    FormRadioButtonGroup,
+    FormTextArea,
+    FormDatePicker,
+    FormHtmlEditor,
+    ...editor,
+    ...inspector,
+    ...renderer,
+  },
   computed: {
     model() {
       return this.$deepModel(this.transientData);

--- a/vue.config.js
+++ b/vue.config.js
@@ -17,7 +17,7 @@ module.exports = {
       symlinks: false,
     },
     externals: {
-      subtract: ['bootstrap']
+      subtract: ['bootstrap', '@processmaker/vue-form-elements']
     }
   },
 }


### PR DESCRIPTION
This PR fixes issues brought up with the latest QA build:
1. The form doesn't load in the preview page initially (it only loads after making a change in the builder).
2. The first option in a radio group doesn't appear to be visually selected anymore, even though the 1st option is set by default when submitting the form.
3. Fixes #214.

**The accompanying PR on spark is here:** https://github.com/ProcessMaker/spark/pull/1893.
**The accompanying PR on vue-form-elements is here:** https://github.com/ProcessMaker/vue-form-elements/pull/43.

For no. 1 above. the problem was solved by setting the config object to the default config from the `screen` prop on initial load. Before it was only "copying" the form config to the preview page when a change was made (hence why the preview appeared blank after initial load until making a change). 

This fix revealed a couple other bugs: circular dependencies between the form builder/renderer and form elements, and components not being registered in the renderer. This was fixed by deleting an unused import which was causing a circular dependency, and by moving the form component exports up one level and cleaning up the imports.

`@processmaker/vue-form-elements` was also "externalized" and made a peer dependency; this will ensure the screen builder and spark don't end up with different versions of form elements.