### PR TITLE
Adjust draggable options for nested lists

### DIFF
--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -5,7 +5,12 @@
                 <template v-for="(item, index) in items">
                     <draggable :class="classColumn(index)"
                             v-model="items[index]"
-                            :options="{group: {name: 'controls'}}"
+                            :options="{
+                              invertSwap: true,
+                              group: {name: 'controls'},
+                              direction: 'horizontal',
+                              emptyInsertThreshold: 5
+                            }"
                             :key="index">
                         <div class="control-item"
                                 :class="{selected: selected === element}"

--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -1,16 +1,11 @@
 <template>
-    <div :class="classContainer">
+    <div :class="classContainer" class="mb-1 mt-1 pb-0 pt-0">
         <div>
             <div class="row">
                 <template v-for="(item, index) in items">
                     <draggable :class="classColumn(index)"
                             v-model="items[index]"
-                            :options="{
-                              invertSwap: true,
-                              group: {name: 'controls'},
-                              direction: 'horizontal',
-                              emptyInsertThreshold: 5
-                            }"
+                            :options="{group: {name: 'controls'}}"
                             :key="index">
                         <div class="control-item"
                                 :class="{selected: selected === element}"
@@ -124,7 +119,7 @@
 <style lang="scss" scoped>
     .column-draggable {
         border: 1px dashed #000;
-        min-height: 48px;
+        min-height: 80px;
         content: "Drag Controls";
     }
 

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -36,7 +36,7 @@
     </b-col>
 
     <!-- Renderer -->
-    <b-col class="overflow-auto mh-100 pl-4 pr-4">
+    <b-col class="overflow-auto mh-100 pl-4 pr-4 d-flex flex-column">
       <b-input-group size="sm" class="sticky-top bg-white">
         <b-form-select v-model="currentPage" class="form-control">
           <option v-for="(data, page) in config" :key="page" :value="page">{{ data.name }}</option>
@@ -68,10 +68,17 @@
         <hr class="w-100">
       </b-input-group>
       <draggable
+        class="h-100"
         ghost-class="form-control-ghost"
         :value="config[currentPage].items"
         @input="updateConfig"
-        :options="{group: {name: 'controls'}}"
+        :options="{
+          group: {name: 'controls'},
+          direction: 'horizontal',
+          invertSwap: true,
+          invertedSwapThreshold: 0.3,
+          emptyInsertThreshold: 30
+        }"
       >
         <div
           class="control-item"

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -74,14 +74,11 @@
         @input="updateConfig"
         :options="{
           group: {name: 'controls'},
-          direction: 'horizontal',
-          invertSwap: true,
-          invertedSwapThreshold: 0.3,
-          emptyInsertThreshold: 30
+          swapThreshold: 0.5
         }"
       >
         <div
-          class="control-item"
+          class="control-item mt-1 mb-1"
           :class="{selected: selected === element, hasError: hasError(element)}"
           v-for="(element,index) in config[currentPage].items"
           :key="index"
@@ -102,7 +99,7 @@
             </div>
 
             <component
-              class="card-body m-2 mr-3 ml-3 pt-3"
+              class="card-body"
               :class="elementCssClass(element)"
               @inspect="inspect"
               :selected="selected"
@@ -449,10 +446,6 @@ $header-bg: #f7f7f7;
 
 .control-item {
   position: relative;
-
-  &:not(:last-child) {
-    margin-bottom: 1.5rem;
-  }
 
   .delete {
     position: absolute;

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -78,7 +78,7 @@
         }"
       >
         <div
-          class="control-item mt-1 mb-1"
+          class="control-item mt-4 mb-4"
           :class="{selected: selected === element, hasError: hasError(element)}"
           v-for="(element,index) in config[currentPage].items"
           :key="index"


### PR DESCRIPTION
Fixes #221.

Video of fix: https://www.dropbox.com/s/0rynwuzcsiq345x/dragging_improved.mov?dl=0.

The functionality for dragging elements into/out of nested draggable lists (table / multi-column) was already correctly implemented. However, due to styling changes, the relative sizes of elements, and the fact that they can change, made it difficult to line up the drop / swap targets to allow dragging into a nested list.

This PR modifies the properties of the draggable lists to make it easier to interact with nested lists. The descriptions of these options is listed here: https://github.com/SortableJS/Sortable#options.

The [SortableJS example](http://sortablejs.github.io/Sortable/#nested) mentions the following, which has been implemented in this PR:
> NOTE: When using nested Sortables with animation, it is recommended that the fallbackOnBody option is set to true. 
It is also always recommended that either the invertSwap option is set to true, or the swapThreshold option is lower than the default value of 1 (eg 0.65).

To make dragging / dropping as smooth as possible, it would be ideal to keep the dragging elements small, the drop targets large, and the elements in the same relative position for nested lists. This is especially clear when there's an empty multi-column table, and you highlight a form element (having the card with the delete button increases it's size significantly).