### PR TITLE
Multi-column renders Rich Text component

### DIFF
--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -10,7 +10,9 @@
                         <div class="control-item"
                                 :class="{selected: selected === element}"
                                 v-for="(element,row) in item"
-                                :key="row">
+                                :key="row"
+                                @click.stop="inspect(element)"
+                                >
                             <div v-if="element.container" @click.stop="inspect(element)">
                                 <component :class="elementCssClass(element)"
                                         :selected="selected"
@@ -24,11 +26,12 @@
                             <div v-else :id="element.config.name ? element.config.name : undefined">
                                 <component :class="elementCssClass(element)"
                                         v-bind="element.config"
-                                        v-model="element.items"
                                         :config="element.config"
-                                        :is="element['editor-component']">
+                                        @input="element.config.interactive ? element.config.content = $event : null"
+                                        :is="element['editor-component']"
+                                        >
                                 </component>
-                                <div @click.stop="inspect(element)" class="mask"></div>
+                                <div v-if="!element.config.interactive" class="mask" :class="{ selected: selected === element }"></div>
                             </div>
 
                             <button class="delete btn btn-sm btn-danger" @click="deleteItem(index, row)">x</button>

--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -24,6 +24,8 @@
                             <div v-else :id="element.config.name ? element.config.name : undefined">
                                 <component :class="elementCssClass(element)"
                                         v-bind="element.config"
+                                        v-model="element.items"
+                                        :config="element.config"
                                         :is="element['editor-component']">
                                 </component>
                                 <div @click.stop="inspect(element)" class="mask"></div>

--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -53,7 +53,8 @@
     FormTextArea,
     FormCheckbox,
     FormRadioButtonGroup,
-    FormDatePicker
+    FormDatePicker,
+    FormHtmlEditor
   } from "@processmaker/vue-form-elements";
 
   export default {
@@ -71,7 +72,8 @@
       FormButton,
       MultiColumn,
       FormDatePicker,
-      FormImage
+      FormImage,
+      FormHtmlEditor
     },
     data() {
       return {

--- a/src/components/renderer/form-multi-column.vue
+++ b/src/components/renderer/form-multi-column.vue
@@ -58,7 +58,8 @@
     FormTextArea,
     FormCheckbox,
     FormRadioButtonGroup,
-    FormDatePicker
+    FormDatePicker,
+    FormHtmlEditor
   } from "@processmaker/vue-form-elements";
 
   export default {
@@ -75,7 +76,8 @@
       FormButton,
       FormMultiColumn,
       FormDatePicker,
-      FormImage
+      FormImage,
+      FormHtmlEditor
     },
     data() {
       return {


### PR DESCRIPTION
Another bug was exposed, when the Rich Text was rendered in the multi-column, the inspector config values did not update with the rendered Rich Text. Fixed in this PR.

**Spark Video Demo**
https://drive.google.com/open?id=1hiW-QKc9EPirj-Y8UZHu8CB9fdcOR_sA

Fixes #217 