### PR TITLE
Fix text color select & custom css

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-container  class="h-100">
+  <b-container class="h-100" id="screen-builder-container">
     <b-card no-body class="h-100 bg-white" id="app">
       <!-- Card Header -->
       <b-card-header>

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -300,7 +300,7 @@ export default {
       this.parseCss();
     }, 500),
     parseCss() {
-      let containerSelector = "div#screen-builder-container";
+      const containerSelector = "#screen-builder-container";
       try {
         var ast = csstree.parse(this.customCss, {
           onParseError: function(error) {

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="renderer-container">
+  <div>
     <div v-for="(element,index) in config[currentPage]['items']" :key="index">
       <div
         v-if="element.container"
@@ -300,7 +300,7 @@ export default {
       this.parseCss();
     }, 500),
     parseCss() {
-      let containerSelector = "div#renderer-container";
+      let containerSelector = "div#screen-builder-container";
       try {
         var ast = csstree.parse(this.customCss, {
           onParseError: function(error) {

--- a/src/global-properties.js
+++ b/src/global-properties.js
@@ -16,7 +16,7 @@ export default [
                     config: {
                         label: "CSS Selector Name",
                         helper: "Use this in your custom css rules",
-                        validation: 'attr-value'
+                        validation: 'regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]'
                     }
                 }
             ]

--- a/tests/unit/CustomCss.spec.js
+++ b/tests/unit/CustomCss.spec.js
@@ -46,10 +46,10 @@ describe('Test custom css', () => {
   });
 
   it('Test custom CSS rules are scoped', () => {
-    
+
     // Test if the rendered form contains the custom CSS
-    expect(wrapper.html()).toContain('div#renderer-container div{background:green}');
-    expect(wrapper.html()).toContain('div#renderer-container .form-control{color:gray}');
+    expect(wrapper.html()).toContain('div#screen-builder-container div{background:green}');
+    expect(wrapper.html()).toContain('div#screen-builder-container .form-control{color:gray}');
 
   });
 });

--- a/tests/unit/CustomCss.spec.js
+++ b/tests/unit/CustomCss.spec.js
@@ -48,8 +48,8 @@ describe('Test custom css', () => {
   it('Test custom CSS rules are scoped', () => {
 
     // Test if the rendered form contains the custom CSS
-    expect(wrapper.html()).toContain('div#screen-builder-container div{background:green}');
-    expect(wrapper.html()).toContain('div#screen-builder-container .form-control{color:gray}');
+    expect(wrapper.html()).toContain('#screen-builder-container div{background:green}');
+    expect(wrapper.html()).toContain('#screen-builder-container .form-control{color:gray}');
 
   });
 });


### PR DESCRIPTION
- The fix for the text-colour bug requires changes in the spark repo. There is a PR in spark repo for it (https://github.com/ProcessMaker/spark/pull/1955)
- Adding a custom class threw an error, the validation was not properly working
- Fix custom css styles,
     - styles were not being applied to the design view but only the preview 

**Spark Video Demo - Text Color Fix**
https://drive.google.com/open?id=15tSnFtkOju6pN3BPFcfiBIJ3nFjiyl-2

**Spark Video Demo - Custom Css Fix**
https://drive.google.com/open?id=1nZPsd_oxCWNzdVkfGUqM88qcY8O80tLo


Fixes #223 